### PR TITLE
Update version to 0.30.0

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,4 +2,7 @@
 
 set -exuo pipefail
 
+# Remove bundled dependencies
+rm -rf crt
+
 $PYTHON -m pip install . -vv --no-deps --no-build-isolation

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "awscrt" %}
-{% set version = "0.27.4" %}
+{% set version = "0.30.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,14 +7,14 @@ package:
 
 source:
   url: https://pypi.org/packages/source/a/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: cb23cb767ca2e3c0007c899b289d668d28aeb055534df35a741847135f6cd91c
+  sha256: e1a133430e71116e9c0f101b0d11227f47b7c561ad5303f5af00f6c33a16f382
   patches:
     - patches/0001-Don-t-force-static-linkage.patch
     - patches/0002-disable-osx-failing-tests.patch  # [osx]
     - patches/0003-disable-win-failing-test.patch  # [win]
 
 build:
-  number: 1
+  number: 0
   skip: true  # [py<38]
   script_env:
     # Unvendor AWS libs
@@ -42,17 +42,17 @@ requirements:
     - wheel >=0.45.1
     - s2n {{ s2n }}  # [linux]
     - openssl {{ openssl }}  # [not linux]
-    - aws-c-common 0.12.4
+    - aws-c-common 0.12.6
     - aws-c-sdkutils 0.2.4
-    - aws-c-cal 0.9.2
-    - aws-c-io 0.21.4
-    - aws-checksums 0.2.7
+    - aws-c-cal 0.9.13
+    - aws-c-io 0.23.3
+    - aws-checksums 0.2.8
     - aws-c-compression 0.3.1
-    - aws-c-event-stream 0.5.6
-    - aws-c-http 0.10.4
-    - aws-c-auth 0.9.0
+    - aws-c-event-stream 0.5.9
+    - aws-c-http 0.10.7
+    - aws-c-auth 0.9.4
     - aws-c-mqtt 0.13.3
-    - aws-c-s3 0.8.7
+    - aws-c-s3 0.11.3
   run:
     - python
 


### PR DESCRIPTION
awscrt 0.30.0

**Destination channel:** defaults

### Links

- [PKG-11436](https://anaconda.atlassian.net/browse/PKG-11436) 
- [Upstream repository](https://github.com/awslabs/aws-crt-python/tree/v0.30.0)

### Explanation of changes:

- New version number
- Updating dependencies


[PKG-11436]: https://anaconda.atlassian.net/browse/PKG-11436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ