### PR TITLE
awscrt 0.32.0 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,8 +1,0 @@
-channels:
-  - https://staging.continuum.io/preprod-pbp/fs/aws-c-io-feedstock/pr7/928beff
-  - https://staging.continuum.io/preprod-pbp/fs/aws-c-compression-feedstock/pr6/8a902d3
-  - https://staging.continuum.io/preprod-pbp/fs/aws-c-http-feedstock/pr7/c623fb1
-  - https://staging.continuum.io/preprod-pbp/fs/aws-c-auth-feedstock/pr7/15f9a47
-  - https://staging.continuum.io/preprod-pbp/fs/aws-c-mqtt-feedstock/pr7/772b912
-  - https://staging.continuum.io/preprod-pbp/fs/aws-c-event-stream-feedstock/pr10/f10fc1d
-  - https://staging.continuum.io/preprod-pbp/fs/aws-c-s3-feedstock/pr8/f579a73

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,8 @@
+channels:
+  - https://staging.continuum.io/preprod-pbp/fs/aws-c-io-feedstock/pr7/928beff
+  - https://staging.continuum.io/preprod-pbp/fs/aws-c-compression-feedstock/pr6/8a902d3
+  - https://staging.continuum.io/preprod-pbp/fs/aws-c-http-feedstock/pr7/c623fb1
+  - https://staging.continuum.io/preprod-pbp/fs/aws-c-auth-feedstock/pr7/15f9a47
+  - https://staging.continuum.io/preprod-pbp/fs/aws-c-mqtt-feedstock/pr7/772b912
+  - https://staging.continuum.io/preprod-pbp/fs/aws-c-event-stream-feedstock/pr10/f10fc1d
+  - https://staging.continuum.io/preprod-pbp/fs/aws-c-s3-feedstock/pr8/f579a73

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,14 +45,14 @@ requirements:
     - aws-c-common 0.12.6
     - aws-c-sdkutils 0.2.4
     - aws-c-cal 0.9.13
-    - aws-c-io 0.23.3
-    - aws-checksums 0.2.8
-    - aws-c-compression 0.3.1
-    - aws-c-event-stream 0.5.9
-    - aws-c-http 0.10.7
-    - aws-c-auth 0.9.4
-    - aws-c-mqtt 0.13.3
-    - aws-c-s3 0.11.3
+    - aws-c-io 0.26.3
+    - aws-checksums 0.2.10
+    - aws-c-compression 0.3.2
+    - aws-c-event-stream 0.6.1
+    - aws-c-http 0.10.13
+    - aws-c-auth 0.10.1
+    - aws-c-mqtt 0.15.2
+    - aws-c-s3 0.12.0
   run:
     - python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "awscrt" %}
-{% set version = "0.30.0" %}
+{% set version = "0.32.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/a/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: e1a133430e71116e9c0f101b0d11227f47b7c561ad5303f5af00f6c33a16f382
+  sha256: 92e749fce6c61da8db1af0baa6b7e96f7acf8a5574760b3d7880d190cedee8a0
   patches:
     - patches/0001-Don-t-force-static-linkage.patch
     - patches/0002-disable-osx-failing-tests.patch  # [osx]


### PR DESCRIPTION
awscrt 0.32.0 

**Destination channel:** Defaults

### Links

- [PKG-13536]
- dev_url:        https://github.com/awslabs/aws-crt-python/tree/v0.32.0
- conda_forge:    https://github.com/conda-forge/awscrt-feedstock
- pypi:           https://pypi.org/project/awscrt/0.32.0
- pypi inspector: https://inspector.pypi.io/project/awscrt/0.32.0

### Explanation of changes:

- new version number


[PKG-13536]: https://anaconda.atlassian.net/browse/PKG-13536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ